### PR TITLE
enable https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,45 @@
 
 SRC_DIR	:=	.
 
-.PHONY: all up clean fclean re purgedb
+.PHONY: all up down clean fclean re purgedb debug
+
+# https://serverfault.com/questions/1108735/how-to-allow-a-docker-container-to-bind-a-privileged-port-as-another-user
+# sysctl:
+#   net.ipv4.ip_unprivileged_port_start: 0
+
+HOST=$(shell hostname)
+
+ifneq (,$(findstring 42barcelona.co.comm, $(HOST) ))
+export HTTP_PORT=8000
+export HTTPS_PORT=8443
+endif
 
 all: up
 
-up:
-	docker compose -f $(SRC_DIR)/docker-compose.yml \
-		--env-file .env \
-		up --build --detach
+debug:
+	DEBUG=true docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env up --build
+
+up: crt.pem
+	docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env up --build --detach
+
+crt.pem: key.pem
+	openssl req -x509 -key $< -out $@ -subj "/C=ES/ST=Catalunya/O=PINGpongMOJOdojoCASAhouse/"
+
+key.pem:
+	openssl genrsa -out $@
 		
+down:
+	docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env down
+
+stop:
+	docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env stop
+
 clean:
 	docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env down
 
 fclean: clean
-	docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env down --volumes
+	rm -rf node_modules
+	rm -rf static
 
 re: fclean up
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRC_DIR	:=	.
 
 HOST=$(shell hostname)
 
-ifneq (,$(findstring 42barcelona.co.comm, $(HOST) ))
+ifneq (,$(findstring 42barcelona.com, $(HOST) ))
 export HTTP_PORT=8000
 export HTTPS_PORT=8443
 endif

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 all: up
 
-debug:
+debug: crt.pem
 	DEBUG=true docker compose -f $(SRC_DIR)/docker-compose.yml --env-file .env up --build
 
 up: crt.pem

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -3,6 +3,12 @@
 #TODO: https://docs.python.org/3/tutorial/venv.html
 
 python3 manage.py collectstatic --noinput
-python3 manage.py makemigrations --noinput
+python3 manage.py makemigrations app --noinput
 python3 manage.py migrate
-python3 manage.py runserver '0.0.0.0:8000'
+
+if test "$DEBUG" = "true"
+then
+	python3 manage.py runserver '0.0.0.0:80'
+else
+	daphne -e ssl:443:privateKey=key.pem:certKey=crt.pem transcendence.asgi:application -b '0.0.0.0' -p 80
+fi

--- a/django-entrypoint.sh
+++ b/django-entrypoint.sh
@@ -8,7 +8,8 @@ python3 manage.py migrate
 
 if test "$DEBUG" = "true"
 then
-	python3 manage.py runserver '0.0.0.0:80'
+	python3 manage.py runserver '0.0.0.0:80' &
+	python3 manage.py runsslserver '0.0.0.0:443'
 else
 	daphne -e ssl:443:privateKey=key.pem:certKey=crt.pem transcendence.asgi:application -b '0.0.0.0' -p 80
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,31 +16,33 @@ services:
         restart: true
     entrypoint: ./django-entrypoint.sh
     environment:
-      DEBUG: "True"
+      DEBUG: ${DEBUG:-false}
+      42_API_ENDPOINT: https://api.intra.42.fr
       ALLOWED_HOSTS: localhost,dump-ubuntu-barcelona
       SECRET_KEY: tr-secret-key
       DB_ENGINE: django.db.backends.postgresql
-      DB_NAME: $(DB_NAME?err}
+      DB_NAME: ${DB_NAME?err}
       DB_USER: ${DB_USER?err}
       DB_PASSWORD: ${DB_PASSWORD?err}
-      DB_HOST: tr-database
+      DB_HOST: database
       DB_PORT: 5432
       DOMAIN: localhost
       DOMAIN_URL: http://localhost
-      REDIS_HOST: tr-redis
+      REDIS_HOST: redis
       REDIS_PORT: 6379
       DEFAULT_FROM_EMAIL: no-reply@dump-ubuntu-barcelona
       STATIC_URL: /static/
       STATIC_ROOT: static
       MEDIA_URL: /media/
-      EMAIL_HOST: tr-mail
+      EMAIL_HOST: mailhog
       EMAIL_USE_TLS: "False"
       EMAIL_USE_SSL: "False"
       EMAIL_PORT: 1025
       EMAIL_USER: tr-mail@tr.mail
       EMAIL_PASSWORD: tr-password
     expose:
-      - 8000
+      - 80
+      - 443
     image: python:3.12-alpine3.20-django
     networks:
       - tr-network
@@ -57,7 +59,7 @@ services:
       - 5432
     healthcheck:
       # pg_isready might be configured with more arguments (host, port, user)
-      test: ["CMD-SHELL", "pg_isready --dbname $${DB_NAME} --username $${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready --dbname ${DB_NAME} --username ${DB_USER}"]
       interval: 1s
       timeout: 8s
       start_period: 4s
@@ -83,7 +85,7 @@ services:
 
   server:
     container_name: tr-server
-    image: caddy:2.8-alpine
+    image: nginx:1.26-alpine3.20
     depends_on:
       django:
         condition: service_started
@@ -91,12 +93,12 @@ services:
     networks:
       - tr-network
     ports:
-      - 8000:80
-      #- 443:443
+      - ${HTTP_PORT:-80}:80
+      - ${HTTPS_PORT:-443}:443
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./caddy_data:/data
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./:/usr/app/
+    working_dir: /usr/app/
 
   mailhog:
     container_name: tr-mail

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,88 @@
+user nginx;
+worker_processes auto;
+error_log stderr info;
+
+include /etc/nginx/modules/*.conf;
+
+events {
+	worker_connections 1024;
+}
+
+http {
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	server_tokens off;
+	client_max_body_size 1m;
+	sendfile on;
+	tcp_nopush on;
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_prefer_server_ciphers on;
+	ssl_session_cache shared:SSL:2m;
+	ssl_session_timeout 1h;
+	ssl_session_tickets off;
+	gzip on;
+
+	resolver 127.0.0.11;
+
+	#map $http_upgrade $connection_upgrade {
+	#	default upgrade;
+	#		'' close;
+	#}
+
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+			'$status $body_bytes_sent "$http_referer" '
+			'"$http_user_agent" "$http_x_forwarded_for"';
+	
+	server {
+		listen 80;
+		server_name localhost dump-ubuntu-barcelona;
+	
+		root /usr/app/;
+		ssl_certificate /usr/app/crt.pem;
+		ssl_certificate_key /usr/app/key.pem;
+	
+		location /media/ {
+			limit_except GET {
+				allow all;
+			}
+		}
+		location /static/ {
+			limit_except GET {
+				allow all;
+			}
+		}
+		location / {
+			proxy_pass http://tr-backend:80/;
+			proxy_pass_request_headers on;
+			proxy_set_header Host $host;
+		}
+
+	}
+	
+	server {
+		listen 443 ssl;
+		server_name localhost dump-ubuntu-barcelona;
+	
+		root /usr/app/;
+		ssl_certificate /usr/app/crt.pem;
+		ssl_certificate_key /usr/app/key.pem;
+	
+		location /media/ {
+			limit_except GET {
+				allow all;
+			}
+		}
+		location /static/ {
+			limit_except GET {
+				allow all;
+			}
+		}
+		location / {
+			proxy_pass https://tr-backend:443/;
+			proxy_pass_request_headers on;
+			proxy_set_header Host $host;
+		}
+
+	}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,17 +10,22 @@ cryptography==43.0.0
 daphne==4.1.2
 Django==5.1
 Faker==28.0.0
+h2==4.1.0
+hpack==4.0.0
+hyperframe==6.0.1
 hyperlink==21.0.0
 idna==3.7
 incremental==24.7.2
 msgpack==1.0.8
 msgpack-python==0.5.6
 pillow==10.4.0
+priority==1.3.0
 psycopg2-binary==2.9.9
 pyasn1==0.6.0
 pyasn1_modules==0.4.0
 pycparser==2.22
 pyOpenSSL==24.2.1
+python-dateutil==2.9.0.post0
 redis==5.0.8
 service-identity==24.1.0
 setuptools==72.1.0
@@ -31,4 +36,3 @@ txaio==23.1.1
 typing_extensions==4.12.2
 wheel==0.44.0
 zope.interface==7.0.1
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ constantly==23.10.4
 cryptography==43.0.0
 daphne==4.1.2
 Django==5.1
+django-sslserver-v2==1.0
 Faker==28.0.0
 h2==4.1.0
 hpack==4.0.0

--- a/transcendence/settings.py
+++ b/transcendence/settings.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get( "SECRET_KEY" )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get( "DEBUG", "True" ) == "True"
+DEBUG = os.environ.get( "DEBUG", "true" ) == "true"
 
 ALLOWED_HOSTS = os.environ.get( "ALLOWED_HOSTS" ).split( "," )
 
@@ -112,7 +112,7 @@ MEDIA_URL = os.environ.get( "MEDIA_URL" )
 
 DOMAIN = os.environ.get( "DOMAIN" )
 DOMAIN_URL = os.environ.get( "DOMAIN_URL" )
-CSRF_TRUSTED_ORIGINS = [DOMAIN_URL]
+CSRF_TRUSTED_ORIGINS = [DOMAIN_URL, "https://localhost", "https://dump-ubuntu-barcelona:8443"]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
@@ -139,3 +139,7 @@ CHANNEL_LAYERS = {
 		}
 
 ASGI_APPLICATION = 'transcendence.asgi.application'
+
+LOGIN_REDIRECT_URL = 'profile'
+LOGIN_URL = 'login'
+LOGOUT_URL = 'logout'

--- a/transcendence/settings.py
+++ b/transcendence/settings.py
@@ -22,6 +22,7 @@ ALLOWED_HOSTS = os.environ.get( "ALLOWED_HOSTS" ).split( "," )
 # Application definition
 
 INSTALLED_APPS = [
+    'sslserver',
 	'daphne',
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
~~Running `make debug` won't enable https mainly because https is not compatible with `runserver` (django's development server).~~ -> Solved as of commit ac6e998c49447106e78df81427cb2c444a0c0f2f 
Running `make` enables https on port 443 (there are exceptions, see Makefile), also http on port 80 (also check Makefile for exceptions).